### PR TITLE
refactor: remove unnecessary turntaken flag

### DIFF
--- a/entities/Events.js
+++ b/entities/Events.js
@@ -25,7 +25,6 @@ module.exports = function (eventBus, userInterface, gameState) {
   function startTurn() {
     const player = gameState.currentPlayer;
     // TODO: refactor to setup function
-    gameState.turnTaken = false;
     gameState.speedingCounter = 0;
     userInterface.startTurn(player);
 
@@ -66,8 +65,6 @@ module.exports = function (eventBus, userInterface, gameState) {
   }
 
   function diceRolled([roll1, roll2]) {
-    // dirty the turnTaken flag for end turn
-    gameState.turnTaken = true;
     userInterface.diceRollResults(roll1, roll2);
     gameState.lastRoll = roll1 + roll2;
     const isDoubles = roll1 === roll2;

--- a/entities/GameState.js
+++ b/entities/GameState.js
@@ -7,7 +7,6 @@ const { cloneDeep } = require("lodash");
 */
 class GameState {
   turn = 0;
-  turnTaken = false;
   players = [];
   _allPlayerActions = {};
   _currentPlayerActions = {};

--- a/entities/PlayerActions.js
+++ b/entities/PlayerActions.js
@@ -8,7 +8,7 @@ module.exports = function (eventBus, userInterface, gameState) {
     ROLL_DICE: {
       execute: rollDice,
       isAvailable: (_, gameState) =>
-        !gameState.turnTaken || (gameState.speedingCounter > 0),
+        !gameState.lastRoll || (gameState.speedingCounter > 0),
       toggleDisplay: (shouldDisplay) => userInterface.rollDiceDisplay(shouldDisplay),
     },
     // USE_GET_OUT_OF_JAIL_CARD,
@@ -24,7 +24,7 @@ module.exports = function (eventBus, userInterface, gameState) {
       execute: endTurn,
       // FUTURE: think about bankrupt or jail
       isAvailable: (_, gameState) =>
-        gameState.turnTaken && (gameState.speedingCounter === 0),
+        !!gameState.lastRoll && (gameState.speedingCounter === 0),
       toggleDisplay: (shouldDisplay) => userInterface.endTurnDisplay(shouldDisplay),
     },
     // CONSTRUCT_HOUSE,
@@ -40,6 +40,7 @@ module.exports = function (eventBus, userInterface, gameState) {
   function endTurn() {
     userInterface.endTurn();
     // UI: fancy game animation
+    delete gameState.lastRoll;
     gameState.turn++;
     // begin next turn
     eventBus.emit("START_TURN");

--- a/entities/PropertyService.js
+++ b/entities/PropertyService.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 /**
  * Responsibility: 
  *   Defines a model and associated metadata for a space on the game board.

--- a/test/Events.test.js
+++ b/test/Events.test.js
@@ -67,12 +67,10 @@ describe("Events", () => {
     });
   });
   describe("startTurn", () => {
-    it("should reset speeding counter and turn taken flag", () => {
+    it("should reset speeding counter", () => {
       gameState.speedingCounter = 1;
-      gameState.turnTaken = true;
       EVENTS.START_TURN();
       expect(gameState.speedingCounter).to.equal(0, "Speeding counter should be reset to 0");
-      expect(gameState.turnTaken).to.equal(false, "Turn should not be taken at the start of turn");
     });
     it("should emit continue turn event", () => {
       const continueTurnSpy = sinon.spy();
@@ -168,11 +166,6 @@ describe("Events", () => {
     });
   });
   describe("diceRolled", () => {
-    it("should set turn taken flag to true", () => {
-      gameState.turnTaken = false;
-      EVENTS.DICE_ROLLED([1, 2]);
-      expect(gameState.turnTaken).to.equal(true);
-    });
     it("should make ui call", () => {
       const uiSpy = sinon.spy();
       mockUI.diceRollResults = uiSpy;

--- a/test/PlayerActions/END_TURN.test.js
+++ b/test/PlayerActions/END_TURN.test.js
@@ -84,7 +84,7 @@ describe("PlayerActions -> END_TURN", () => {
             [1, 3],
         ]);
         PLAYER_ACTIONS.ROLL_DICE.execute();
-        gameState.turnTaken = true;
+        gameState.lastRoll = 4;
 
         result = methodUnderTest();
         expect(result).to.equal(true, "Unavailable after rolling dice");
@@ -97,15 +97,17 @@ describe("PlayerActions -> END_TURN", () => {
             [3, 4]
         ]);
         PLAYER_ACTIONS.ROLL_DICE.execute();
-        gameState.turnTaken = true;
+        gameState.lastRoll = 2;
         gameState.speedingCounter++;
         
         let result = methodUnderTest();
         expect(result).to.equal(false, "Available on doubles");
         
         PLAYER_ACTIONS.ROLL_DICE.execute();
+        gameState.lastRoll = 4;
         gameState.speedingCounter++;
         PLAYER_ACTIONS.ROLL_DICE.execute();
+        gameState.lastRoll = 7;
         gameState.speedingCounter = 0;
         
         result = methodUnderTest();

--- a/test/PlayerActions/ROLL_DICE.test.js
+++ b/test/PlayerActions/ROLL_DICE.test.js
@@ -81,7 +81,7 @@ describe("PlayerActions -> ROLL_DICE", () => {
         [1, 3],
       ]);
       PLAYER_ACTIONS.ROLL_DICE.execute();
-      gameState.turnTaken = true;
+      gameState.lastRoll = 4;
 
       result = methodUnderTest();
       expect(result).to.equal(false, "Action was available after first dice roll");
@@ -91,7 +91,7 @@ describe("PlayerActions -> ROLL_DICE", () => {
         [1, 1],
       ]);
       PLAYER_ACTIONS.ROLL_DICE.execute();
-      gameState.turnTaken = true;
+      gameState.lastRoll = 2;
       gameState.speedingCounter++;
 
       let result = methodUnderTest();


### PR DESCRIPTION
I realized that lastRoll can serve the same purpose and reduce the need for an extraneous property.

Also, should we be explicitly defining `lastRoll` on GameState like we did with `turnTaken`?