### PR TITLE
feat: #32 buy property and resolve it

### DIFF
--- a/ConsoleUI.js
+++ b/ConsoleUI.js
@@ -16,6 +16,7 @@ const consoleUI = (function (readline) {
         chalk.magenta(`AVAILABLE ACTIONS: `) +
           chalk.cyan(`${actions.join(', ')}`)
       ),
+    displayPropertyDetails: (boardProperty) => console.dir(boardProperty),
     prompt: readline.question,
     endTurn: () => console.log(chalk.bold.red('ENDING TURN')),
     rollingDice: () => console.log('🎲ROLLING🎲'),
@@ -51,6 +52,7 @@ const consoleUI = (function (readline) {
       console.log(
         `Game ended. Winner is: 🎉${name}🎉 with a net worth of: ${netWorth}`
       ),
+    propertyBought: () => console.log('Property bought! 🎉🎉'),
   };
 })(require('readline-sync'));
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Capitalism, Ahoy
+# Capitalism, Ahoy
 
 [![Build Status](https://travis-ci.com/eginwong/capitalism-ahoy.svg?branch=master)](https://travis-ci.com/eginwong/capitalism-ahoy)
 [![codecov](https://codecov.io/gh/eginwong/capitalism-ahoy/branch/master/graph/badge.svg)](https://codecov.io/gh/eginwong/capitalism-ahoy)
@@ -19,80 +19,11 @@
 
 ### FUNCTIONALITY
 
-- ~~TODO: Complete a turn~~
-- ~~TODO: VALIDATION, do not allow user to end turn without rolling dice~~
-- ~~TODO: add end game function to stop execution?~~
-- TODO: UI implementation for frontend
-  - material-ui to make things look nice
-  - display properties
-  - move pieces
-- TODO: random array of movement emojis
-  - read: emoji manifesto
-- TODO: enforce global house limits (32), hotel limits (12)
-- TODO: game log
-- TODO: continue game
-- TODO: remaining
-  - ~~startTurn~~
-  - ~~PropertyService~~
-  - ~~MoveService?~~
-    - ~~gameState must have extra configuration~~
-  - ~~PropertyLookupService? (retrieves position / tile meta to determine auction/buy/no-op/rent)~~
-  - WealthService
-    - liquidity
-    - bankruptcy
-  - CardService
-    - USE_GET_OUT_OF_JAIL_CARD
-  - PropertyManagementService
-    - service to manage property purchasing/global maximums
-    - CONSTRUCT_HOUSE,
-    - DECONSTRUCT_HOUSE,
-    - CONSTRUCT_HOTEL,
-    - DECONSTRUCT_HOTEL,
-    - MORTGAGE_PROPERTY,
-      - MortgageService?
-    - AUCTION
-    - BUY
-    - RENT value
-      - PAY_RENT (determines rent / monopoly)
-  - BONUS:
-    - Players
-- ~~TODO: Pass in options to set fine/go parameters/max houses~~
+- TODO
 
 ### ARCHITECTURE
 
-- Services
-  - BuildingService (buy/sell houses, enforce housing limits, handle buy/sell logic)
-    - requires propertyService OR gameState
-  - PropertyService (lookup of position <-> property, calculates rent, handles auctions/purchases/sales of property)
-  - CashManagementService (networth calculation, increment, decrement, liquidation, bankruptcy)
-    - Q: need to know when to calculate networth
-    - requires player
-  - CardService (community chest, chance, randomly draws card from open deck, shuffles)
-- PlayerActions
-  - main actors
-- Events
-  - main actors
-- GameState
-  - glue
-- Game
-  - glue, configuration, start/continue
-- main
-- TODO: One-Pager Architecture Write-up :: Keegan
-
-### CODE
-
-- ~~TODO: testing framework~~
-- ~~TODO: TDD/BDD (given when then), integration testing framework~~
-- ~~TODO: chalk for console UI + testing~~
-- ~~TODO: set up travis ci for test coverage check~~
-- ~~TODO: look into removing gameState from PlayerActions#execute by passing it in~~
-- ~~TODO: Investigate using Mocha's reporter flag for NYC~~
-- ~~TODO: linter~~
-- ~~TODO: prettier~~
-- ~~TODO: [add check for if there are formatting changes outstanding on build](https://github.com/yyx990803/yorkie)~~
-- TODO: validate GameState
-- TODO: use inquirer for [console selection](https://medium.com/@zorrodg/integration-tests-on-node-js-cli-part-2-testing-interaction-user-input-6f345d4b713a) and [tests](https://glebbahmutov.com/blog/unit-testing-cli-programs/)
-- TODO: Refactor Mocha-bloat (not a Mocha-Float); leverage modules
+- TODO: one pager here
 
 ### REFLECTIONS
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## TODO
 
-### FUNCTIONALITY
+### FEATURES
 
 - TODO
 

--- a/entities/Rules/highestRollingPlayerGoesFirst.js
+++ b/entities/Rules/highestRollingPlayerGoesFirst.js
@@ -19,4 +19,7 @@ module.exports = function highestRollingPlayerGoesFirst({ UI }, { players }) {
   // TODO: Handle Ties
   let shiftValue = (players.length - highest) % players.length;
   for (; shiftValue > 0; --shiftValue) players.push(players.shift());
+
+  // add ids to players
+  for (let id = 0; id < players.length; id++) players[id].id = id;
 };

--- a/entities/Rules/highestRollingPlayerGoesFirst.js
+++ b/entities/Rules/highestRollingPlayerGoesFirst.js
@@ -1,6 +1,7 @@
-// TODO: TEST
 /**
  * Rule: Highest Rolling Player Goes First
+ *   Based on the highest rolling player and then beginning clockwise from there to set the
+ *   player order.
  * Effect: Reorder PlayerList Component based on Contest with Dice Component
  */
 module.exports = function highestRollingPlayerGoesFirst({ UI }, { players }) {
@@ -11,15 +12,12 @@ module.exports = function highestRollingPlayerGoesFirst({ UI }, { players }) {
     console.log(`\t\t   `, roll);
     return roll;
   });
-  let { hIndex: highest } = rolls.reduce(
+  let { hIndex: shiftValue } = rolls.reduce(
     ({ hValue = 0, hIndex = 0 }, roll, index) =>
       roll > hValue ? { hValue: roll, hIndex: index } : { hValue, hIndex },
     {}
   );
-  // TODO: Handle Ties
-  let shiftValue = (players.length - highest) % players.length;
-  for (; shiftValue > 0; --shiftValue) players.push(players.shift());
 
-  // add ids to players
-  for (let id = 0; id < players.length; id++) players[id].id = id;
+  // TODO: Handle Ties
+  for (; shiftValue > 0; --shiftValue) players.push(players.shift());
 };

--- a/entities/Rules/index.js
+++ b/entities/Rules/index.js
@@ -12,12 +12,11 @@ module.exports = {
       require('./highestRollingPlayerGoesFirst')({ notify, UI }, gameState);
       notify('PLAYER_ORDER_CHANGED');
     },
-    ({ notify }) => notify('START_TURN'), // require('./playerTurnsStart')
+    ({ notify }) => notify('START_TURN'),
   ],
   START_TURN: [
     ({ notify }, gameState) => {
       require('./resetTurnAssociatedValues')({
-        // (require('./Defaults/turnValues')),
         speedingCounter: 0,
       })(gameState);
       notify('TURN_VALUES_RESET');
@@ -214,8 +213,6 @@ module.exports = {
     },
     ({ notify, UI }, gameState) => {
       const boardProperty = gameState.currentBoardProperty;
-
-      // TODO
       const playerBuyingPower = require('../WealthService').calculateLiquidity(
         gameState
       );

--- a/entities/Rules/index.js
+++ b/entities/Rules/index.js
@@ -133,7 +133,6 @@ module.exports = {
     ({ notify }, gameState) => {
       const boardProperty = gameState.currentBoardProperty;
 
-      // if has property owned, means property can be purchased
       if (boardProperty.ownedBy === -1) {
         notify('RESOLVE_NEW_PROPERTY');
       }

--- a/entities/Rules/index.js
+++ b/entities/Rules/index.js
@@ -244,9 +244,8 @@ module.exports = {
       const boardProperty = gameState.currentBoardProperty;
 
       // checking buying power first in case we have a cancel option in the future
-      // TODO
       // const playerBuyingPower = require('../WealthService').calculateLiquidity(
-      //   gameState.currentPlayer
+      //   gameState
       // );
 
       // if (playerBuyingPower < boardProperty.price) {

--- a/entities/Rules/index.js
+++ b/entities/Rules/index.js
@@ -94,14 +94,18 @@ module.exports = {
     },
     ({ notify }, gameState) => {
       if (gameState.currentPlayer.jailed > 2) {
+        require('./updateTurnValues')({
+          forcedPayFine: true,
+        })(gameState);
+        notify('TURN_VALUES_UPDATED');
         notify('PAY_FINE');
       }
     },
     ({ notify }, gameState) => {
       if (gameState.currentPlayer.jailed === -1) {
-        // TODO: make sure no next movement if doubles out of jail
-        // TODO: but can move twice if paid fine/used card
         notify('MOVE_PLAYER');
+      } else {
+        notify('CONTINUE_TURN');
       }
     },
   ],
@@ -162,7 +166,12 @@ module.exports = {
         notify('LIQUIDATION');
       }
     },
-    ({ notify }) => notify('CONTINUE_TURN'),
+    ({ notify }, { turnValues }) => {
+      // allow continue turn as normal if pre-emptive paying of fine
+      if (!turnValues.forcedPayFine) {
+        notify('CONTINUE_TURN');
+      }
+    },
   ],
   SPEEDING: [({ UI }) => UI.caughtSpeeding(), ({ notify }) => notify('JAIL')],
   PASS_GO: [

--- a/entities/WealthService.js
+++ b/entities/WealthService.js
@@ -31,4 +31,17 @@ module.exports = class WealthService {
   static calculateNetWorth(player) {
     return player.cash + player.assets;
   }
+
+  /**
+   * Determine a player's available funds
+   * @param {*} gameState
+   * @param {*} player
+   */
+  static calculateLiquidity(gameState, player = gameState.currentPlayer) {
+    // TODO: do not divide by 2 any assets that are mortgaged;
+
+    // const hasMonopoly = gameState.config.propertyConfig.properties.filter(p => p.group === boardProperty.group)
+    // .every(p => p.ownedBy === player.id);
+    return player.assets / 2 + player.cash;
+  }
 };

--- a/entities/WealthService.js
+++ b/entities/WealthService.js
@@ -38,10 +38,17 @@ module.exports = class WealthService {
    * @param {*} player
    */
   static calculateLiquidity(gameState, player = gameState.currentPlayer) {
-    // TODO: do not divide by 2 any assets that are mortgaged;
-
-    // const hasMonopoly = gameState.config.propertyConfig.properties.filter(p => p.group === boardProperty.group)
-    // .every(p => p.ownedBy === player.id);
-    return player.assets / 2 + player.cash;
+    const ownedProperties = gameState.config.propertyConfig.properties.filter(
+      (p) => p.ownedBy === player.id
+    );
+    const totalLiquidAssets = ownedProperties
+      .filter((p) => !p.mortgaged)
+      .map((p) =>
+        p.houseCost && p.buildings
+          ? p.houseCost * p.buildings + p.price
+          : p.price
+      )
+      .reduce((acc, val) => acc + val, 0);
+    return totalLiquidAssets / 2 + player.cash;
   }
 };

--- a/main.js
+++ b/main.js
@@ -19,9 +19,9 @@ gameState.players = [
   createPlayer({ name: 'player2' }),
 ];
 // set id of players
-for (let id = 0; id < gameState.players.length; id++)
-  gameState.players[id].id = id;
-
+gameState.players.forEach((player, index) => {
+  player.id = index;
+});
 gameState.config = require('./config/monopolyConfiguration');
 
 const eventBus = new EventEmitter();

--- a/main.js
+++ b/main.js
@@ -18,6 +18,10 @@ gameState.players = [
   createPlayer({ name: 'player1' }),
   createPlayer({ name: 'player2' }),
 ];
+// set id of players
+for (let id = 0; id < gameState.players.length; id++)
+  gameState.players[id].id = id;
+
 gameState.config = require('./config/monopolyConfiguration');
 
 const eventBus = new EventEmitter();
@@ -32,6 +36,7 @@ require('./entities/Game')({ eventBus, userInterface, gameState });
 function createPlayer({ name }) {
   return {
     name,
+    id: 0,
     position: 0,
     jailed: -1,
     cash: 1500,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       ".prettierignore",
       ".gitignore",
       "*.json",
-      "*.lock"
+      "*.lock",
+      "*.md"
     ],
     "parser": "babel-eslint",
     "parserOptions": {

--- a/test/PlayerActions.test.js
+++ b/test/PlayerActions.test.js
@@ -6,7 +6,7 @@ const { GameState } = require('../entities/GameState');
 const { createPlayer } = require('./testutils');
 const PlayerActions = require('../entities/PlayerActions');
 
-describe('PlayerActions', function () {
+describe('PlayerActions', () => {
   let gameState;
 
   beforeEach(() => {

--- a/test/Rules/BUY_PROPERTY.test.js
+++ b/test/Rules/BUY_PROPERTY.test.js
@@ -14,7 +14,7 @@ describe('Rules -> BUY_PROPERTY', () => {
   let userInterface;
   let eventBus;
   const RULES = require('../../entities/Rules');
-  const ORIENTAL_AVENUE_PROPERTY = 2;
+  const TEST_PROPERTY = 2;
 
   beforeEach(() => {
     gameState = new GameState();
@@ -55,7 +55,7 @@ describe('Rules -> BUY_PROPERTY', () => {
     });
     it('should buy asset and adjust player stats', () => {
       const property =
-        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+        gameState.config.propertyConfig.properties[TEST_PROPERTY];
       gameState.currentBoardProperty = property;
 
       const wealthServiceStub = sinon.stub(WealthService, 'buyAsset');
@@ -71,7 +71,7 @@ describe('Rules -> BUY_PROPERTY', () => {
     });
     it('should update the ownership of the purchased asset', () => {
       const property =
-        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+        gameState.config.propertyConfig.properties[TEST_PROPERTY];
       gameState.currentBoardProperty = property;
 
       eventBus.emit(inputEvent);

--- a/test/Rules/BUY_PROPERTY.test.js
+++ b/test/Rules/BUY_PROPERTY.test.js
@@ -1,0 +1,84 @@
+const expect = require('chai').expect;
+const EventEmitter = require('events');
+const sinon = require('sinon');
+const mockUIFactory = require('../mocks/UI');
+
+const { GameState } = require('../../entities/GameState');
+const { createPlayer } = require('../testutils');
+const config = require('../../config/monopolyConfiguration');
+const WealthService = require('../../entities/WealthService');
+const { cloneDeep } = require('lodash');
+
+describe('Rules -> BUY_PROPERTY', () => {
+  let gameState;
+  let userInterface;
+  let eventBus;
+  const RULES = require('../../entities/Rules');
+  const ORIENTAL_AVENUE_PROPERTY = 2;
+
+  beforeEach(() => {
+    gameState = new GameState();
+    eventBus = new EventEmitter();
+    userInterface = mockUIFactory();
+    gameState.players = [createPlayer({ name: 'player1' })];
+    gameState.config = cloneDeep(config);
+  });
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+
+  describe('buyProperty', () => {
+    const inputEvent = 'BUY_PROPERTY';
+
+    beforeEach(() => {
+      let { emit: notify } = eventBus;
+      notify = notify.bind(eventBus);
+
+      RULES[inputEvent].forEach((handler) =>
+        eventBus.on(
+          inputEvent,
+          handler.bind(null, { notify, UI: userInterface }, gameState)
+        )
+      );
+    });
+
+    it('should make a call to the UI#propertyBought', () => {
+      const uiSpy = sinon.spy();
+      userInterface.propertyBought = uiSpy;
+      eventBus.emit(inputEvent);
+      expect(uiSpy.calledOnce).to.equal(
+        true,
+        `Initial UI method for ${inputEvent} was not called`
+      );
+    });
+    it('should buy asset and adjust player stats', () => {
+      const property =
+        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+      gameState.currentBoardProperty = property;
+
+      const wealthServiceStub = sinon.stub(WealthService, 'buyAsset');
+
+      eventBus.emit(inputEvent);
+      expect(
+        wealthServiceStub.calledOnceWithExactly(
+          gameState.players[0],
+          property.price
+        ),
+        `Player wealth was not updated after ${inputEvent} event`
+      );
+    });
+    it('should update the ownership of the purchased asset', () => {
+      const property =
+        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+      gameState.currentBoardProperty = property;
+
+      eventBus.emit(inputEvent);
+      expect(property.ownedBy).to.equal(
+        gameState.players[0].id,
+        `Property ownership was not updated after ${inputEvent} event`
+      );
+    });
+  });
+});

--- a/test/Rules/JAIL_ROLL.test.js
+++ b/test/Rules/JAIL_ROLL.test.js
@@ -28,9 +28,11 @@ describe('Rules -> JAIL_ROLL', () => {
     const inputEvent = 'JAIL_ROLL';
     const movePlayerEvent = 'MOVE_PLAYER';
     const payFineEvent = 'PAY_FINE';
+    const continueTurnEvent = 'CONTINUE_TURN';
 
     let payFineSpy;
     let movePlayerSpy;
+    let continueTurnSpy;
 
     beforeEach(() => {
       let { emit: notify } = eventBus;
@@ -48,9 +50,11 @@ describe('Rules -> JAIL_ROLL', () => {
       };
       payFineSpy = sinon.spy();
       movePlayerSpy = sinon.spy();
+      continueTurnSpy = sinon.spy();
 
       eventBus.on(payFineEvent, payFineSpy);
       eventBus.on(movePlayerEvent, movePlayerSpy);
+      eventBus.on(continueTurnEvent, continueTurnSpy);
     });
 
     it('should make a call to the UI#rollJailDice', () => {
@@ -86,6 +90,10 @@ describe('Rules -> JAIL_ROLL', () => {
         1,
         `${payFineEvent} event was not called`
       );
+      expect(gameState.turnValues.forcedPayFine).to.equal(
+        true,
+        `enforcePayFine should be set to true on gameState`
+      );
     });
     it('should not emit enforce pay fine if jailed counter is less than or equal to 2', () => {
       gameState.currentPlayer.jailed = 1;
@@ -105,11 +113,11 @@ describe('Rules -> JAIL_ROLL', () => {
         `${movePlayerEvent} event was not called`
       );
     });
-    it(`should not emit ${movePlayerEvent} event if player is in jail`, () => {
+    it(`should not emit ${continueTurnEvent} event if player is in jail`, () => {
       eventBus.emit(inputEvent);
-      expect(movePlayerSpy.callCount).to.equal(
-        0,
-        `${movePlayerEvent} event was called`
+      expect(continueTurnSpy.callCount).to.equal(
+        1,
+        `${continueTurnEvent} event was not called when player is in jail`
       );
     });
   });

--- a/test/Rules/MOVE_PLAYER.test.js
+++ b/test/Rules/MOVE_PLAYER.test.js
@@ -29,8 +29,10 @@ describe('Rules -> MOVE_PLAYER', () => {
   describe('movePlayer', () => {
     const inputEvent = 'MOVE_PLAYER';
     const passGoEvent = 'PASS_GO';
+    const continueTurnEvent = 'CONTINUE_TURN';
 
     let passGoSpy;
+    let continueTurnSpy;
 
     beforeEach(() => {
       let { emit: notify } = eventBus;
@@ -47,7 +49,10 @@ describe('Rules -> MOVE_PLAYER', () => {
       };
 
       passGoSpy = sinon.spy();
+      continueTurnSpy = sinon.spy();
+
       eventBus.on(passGoEvent, passGoSpy);
+      eventBus.on(continueTurnEvent, continueTurnSpy);
     });
 
     it('should set gameState current board property', () => {
@@ -118,6 +123,13 @@ describe('Rules -> MOVE_PLAYER', () => {
       expect(passGoSpy.callCount).to.equal(
         0,
         'Move Player emitted pass go event without wrapping around the board'
+      );
+    });
+    it(`should emit ${continueTurnEvent} event`, () => {
+      eventBus.emit(inputEvent);
+      expect(continueTurnSpy.callCount).to.equal(
+        1,
+        `${continueTurnEvent} event was not called`
       );
     });
   });

--- a/test/Rules/PAY_FINE.test.js
+++ b/test/Rules/PAY_FINE.test.js
@@ -46,6 +46,11 @@ describe('Rules -> PAY_FINE', () => {
           handler.bind(null, { notify, UI: userInterface }, gameState)
         )
       );
+      gameState.turnValues = {
+        roll: [1, 2],
+        speedingCounter: 0,
+      };
+
       bankruptcySpy = sinon.spy();
       liquidationSpy = sinon.spy();
       continueTurnSpy = sinon.spy();
@@ -109,6 +114,14 @@ describe('Rules -> PAY_FINE', () => {
       expect(continueTurnSpy.callCount).to.equal(
         1,
         `${continueTurnEvent} was not called`
+      );
+    });
+    it(`the ${continueTurnEvent} event should not be called if forced to pay fine`, () => {
+      gameState.turnValues.forcedPayFine = true;
+      eventBus.emit(inputEvent);
+      expect(continueTurnSpy.callCount).to.equal(
+        0,
+        `${continueTurnEvent} was called`
       );
     });
   });

--- a/test/Rules/RESOLVE_NEW_PROPERTY.test.js
+++ b/test/Rules/RESOLVE_NEW_PROPERTY.test.js
@@ -1,0 +1,129 @@
+const expect = require('chai').expect;
+const EventEmitter = require('events');
+const sinon = require('sinon');
+const mockUIFactory = require('../mocks/UI');
+
+const { GameState } = require('../../entities/GameState');
+const { createPlayer } = require('../testutils');
+const config = require('../../config/monopolyConfiguration');
+const PlayerActions = require('../../entities/PlayerActions');
+
+describe('Rules -> RESOLVE_NEW_PROPERTY', () => {
+  let gameState;
+  let userInterface;
+  let eventBus;
+  const RULES = require('../../entities/Rules');
+  const ORIENTAL_AVENUE_PROPERTY = 2;
+
+  beforeEach(() => {
+    gameState = new GameState();
+    eventBus = new EventEmitter();
+    userInterface = mockUIFactory();
+    gameState.players = [createPlayer({ name: 'player1' })];
+    gameState.config = config;
+  });
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+
+  describe('resolveNewProperty', () => {
+    const inputEvent = 'RESOLVE_NEW_PROPERTY';
+    const beginAuctionEvent = 'BEGIN_AUCTION';
+    const buyPropertyEvent = 'BUY_PROPERTY';
+
+    let beginAuctionSpy;
+    let buyPropertySpy;
+
+    beforeEach(() => {
+      let { emit: notify } = eventBus;
+      notify = notify.bind(eventBus);
+
+      RULES[inputEvent].forEach((handler) =>
+        eventBus.on(
+          inputEvent,
+          handler.bind(null, { notify, UI: userInterface }, gameState)
+        )
+      );
+      beginAuctionSpy = sinon.spy();
+      buyPropertySpy = sinon.spy();
+
+      eventBus.on(beginAuctionEvent, beginAuctionSpy);
+      eventBus.on(buyPropertyEvent, buyPropertySpy);
+    });
+
+    it('should make a call to the UI#displayPropertyDetails', () => {
+      const uiSpy = sinon.spy();
+      userInterface.displayPropertyDetails = uiSpy;
+      const property =
+        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+      gameState.currentBoardProperty = property;
+
+      const playerActionsStub = sinon.stub(PlayerActions, 'prompt');
+      playerActionsStub.returns(buyPropertyEvent);
+
+      eventBus.emit(inputEvent);
+      expect(
+        uiSpy.calledOnceWithExactly(
+          property,
+          `Initial UI method for ${inputEvent} was not called`
+        )
+      );
+    });
+    it('should automatically begin auction if player does not have enough liquidity', () => {
+      const property =
+        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+      gameState.currentBoardProperty = property;
+      gameState.players[0].cash = 80;
+
+      const playerActionsStub = sinon.stub(PlayerActions, 'prompt');
+
+      const uiSpy = sinon.spy();
+      userInterface.unknownAction = uiSpy;
+
+      eventBus.emit(inputEvent);
+      expect(beginAuctionSpy.calledOnce).to.equal(
+        true,
+        `${beginAuctionEvent} was not called when player did not have enough liquidity`
+      );
+
+      expect(playerActionsStub.callCount).to.equal(
+        0,
+        `Prompt was unexpectedly called in liquidity scenario for ${inputEvent}`
+      );
+    });
+    it('should prompt if player can buy or auction', () => {
+      const property =
+        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+      gameState.currentBoardProperty = property;
+
+      const playerActionsStub = sinon.stub(PlayerActions, 'prompt');
+      playerActionsStub.returns(buyPropertyEvent);
+
+      eventBus.emit(inputEvent);
+      expect(playerActionsStub.getCall(0).args[2]).to.deep.equal(
+        [buyPropertyEvent, beginAuctionEvent],
+        `Prompt method for ${inputEvent} does not have expected options`
+      );
+    });
+    it('should re-run rule if prompt input is not understood', () => {
+      const property =
+        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+      gameState.currentBoardProperty = property;
+
+      const playerActionsStub = sinon.stub(PlayerActions, 'prompt');
+      playerActionsStub.onCall(0).returns(undefined);
+      playerActionsStub.onCall(1).returns(buyPropertyEvent);
+
+      const uiSpy = sinon.spy();
+      userInterface.unknownAction = uiSpy;
+
+      eventBus.emit(inputEvent);
+      expect(uiSpy.calledOnce).to.equal(
+        true,
+        `Prompt method for ${inputEvent} does not handle unknown action`
+      );
+    });
+  });
+});

--- a/test/Rules/RESOLVE_NEW_PROPERTY.test.js
+++ b/test/Rules/RESOLVE_NEW_PROPERTY.test.js
@@ -13,7 +13,7 @@ describe('Rules -> RESOLVE_NEW_PROPERTY', () => {
   let userInterface;
   let eventBus;
   const RULES = require('../../entities/Rules');
-  const ORIENTAL_AVENUE_PROPERTY = 2;
+  const TEST_PROPERTY = 2;
 
   beforeEach(() => {
     gameState = new GameState();
@@ -57,7 +57,7 @@ describe('Rules -> RESOLVE_NEW_PROPERTY', () => {
       const uiSpy = sinon.spy();
       userInterface.displayPropertyDetails = uiSpy;
       const property =
-        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+        gameState.config.propertyConfig.properties[TEST_PROPERTY];
       gameState.currentBoardProperty = property;
 
       const playerActionsStub = sinon.stub(PlayerActions, 'prompt');
@@ -73,7 +73,7 @@ describe('Rules -> RESOLVE_NEW_PROPERTY', () => {
     });
     it('should automatically begin auction if player does not have enough liquidity', () => {
       const property =
-        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+        gameState.config.propertyConfig.properties[TEST_PROPERTY];
       gameState.currentBoardProperty = property;
       gameState.players[0].cash = 80;
 
@@ -95,7 +95,7 @@ describe('Rules -> RESOLVE_NEW_PROPERTY', () => {
     });
     it('should prompt if player can buy or auction', () => {
       const property =
-        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+        gameState.config.propertyConfig.properties[TEST_PROPERTY];
       gameState.currentBoardProperty = property;
 
       const playerActionsStub = sinon.stub(PlayerActions, 'prompt');
@@ -109,7 +109,7 @@ describe('Rules -> RESOLVE_NEW_PROPERTY', () => {
     });
     it('should re-run rule if prompt input is not understood', () => {
       const property =
-        gameState.config.propertyConfig.properties[ORIENTAL_AVENUE_PROPERTY];
+        gameState.config.propertyConfig.properties[TEST_PROPERTY];
       gameState.currentBoardProperty = property;
 
       const playerActionsStub = sinon.stub(PlayerActions, 'prompt');

--- a/test/Rules/ROLL_DICE.test.js
+++ b/test/Rules/ROLL_DICE.test.js
@@ -30,9 +30,7 @@ describe('Rules -> ROLL_DICE', () => {
     const moveRollEvent = 'MOVE_ROLL';
     const jailRollEvent = 'JAIL_ROLL';
     const turnValuesUpdatedEvent = 'TURN_VALUES_UPDATED';
-    const continueTurnEvent = 'CONTINUE_TURN';
 
-    let continueTurnSpy;
     let turnValuesUpdatedSpy;
     let moveRollSpy;
     let jailRollSpy;
@@ -47,12 +45,10 @@ describe('Rules -> ROLL_DICE', () => {
           handler.bind(null, { notify, UI: userInterface }, gameState)
         )
       );
-      continueTurnSpy = sinon.spy();
       turnValuesUpdatedSpy = sinon.spy();
       moveRollSpy = sinon.spy();
       jailRollSpy = sinon.spy();
 
-      eventBus.on(continueTurnEvent, continueTurnSpy);
       eventBus.on(turnValuesUpdatedEvent, turnValuesUpdatedSpy);
       eventBus.on(moveRollEvent, moveRollSpy);
       eventBus.on(jailRollEvent, jailRollSpy);
@@ -96,13 +92,6 @@ describe('Rules -> ROLL_DICE', () => {
       expect(uiSpy.calledOnceWithExactly(1, 2)).to.equal(
         true,
         `UI method for display roll results of ${inputEvent} was not called`
-      );
-    });
-    it(`should emit ${continueTurnEvent} event`, () => {
-      eventBus.emit(inputEvent);
-      expect(continueTurnSpy.callCount).to.equal(
-        1,
-        `${continueTurnEvent} event was not called`
       );
     });
     it(`should emit ${moveRollEvent} event if player is not in jail`, () => {

--- a/test/Rules/highestRollingPlayerGoesFirst.test.js
+++ b/test/Rules/highestRollingPlayerGoesFirst.test.js
@@ -24,16 +24,6 @@ describe('Rules -> highestRollingPlayerGoesFirst', () => {
     sinon.restore();
   });
 
-  it(`should assign indices to each player`, () => {
-    highestRollingPlayerGoesFirst({ UI: userInterface }, input);
-    for (let index = 0; index < input.players.length; index++) {
-      expect(
-        input.players[index].id === index,
-        `Player index of ${index} does not match player position`
-      );
-    }
-  });
-
   it('should make a call to the UI#prompt', () => {
     const uiSpy = sinon.spy();
     userInterface.prompt = uiSpy;
@@ -43,7 +33,7 @@ describe('Rules -> highestRollingPlayerGoesFirst', () => {
       `UI method for highestRollingPlayerGoesFirst was not called`
     );
   });
-  xit(`should reorder players based on random dice rolls if required`, () => {
+  it(`should reorder players based on random dice rolls if required starting clockwise from largest`, () => {
     diceStub = sinon.stub(Dice, 'roll');
     input.players.push(createPlayer({ name: 'Player3' }));
     input.players.push(createPlayer({ name: 'Player4' }));
@@ -56,25 +46,10 @@ describe('Rules -> highestRollingPlayerGoesFirst', () => {
     diceStub.onCall(4).returns([6]);
 
     highestRollingPlayerGoesFirst({ UI: userInterface }, input);
-    expect(input.players[4].name).to.equal(
-      'Player1',
-      'Unexpected player in order 4'
-    );
-    expect(input.players[3].name).to.equal(
-      'Player2',
-      'Unexpected player in order 3'
-    );
-    expect(input.players[2].name).to.equal(
-      'Player3',
-      'Unexpected player in order 2'
-    );
-    expect(input.players[1].name).to.equal(
-      'Player4',
-      'Unexpected player in order 1'
-    );
-    expect(input.players[0].name).to.equal(
-      'Player5',
-      'Unexpected player in order 0'
+    const reorderedNames = input.players.map((p) => p.name);
+    expect(reorderedNames).to.deep.equal(
+      ['Player5', 'Player1', 'Player2', 'Player3', 'Player4'],
+      'Unexpected player order, not following Clockwise from highest player roll'
     );
   });
   it(`should not reorder players based on random dice rolls if not required`, () => {

--- a/test/Rules/highestRollingPlayerGoesFirst.test.js
+++ b/test/Rules/highestRollingPlayerGoesFirst.test.js
@@ -1,0 +1,95 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const highestRollingPlayerGoesFirst = require('../../entities/Rules/highestRollingPlayerGoesFirst');
+const Dice = require('../../entities/Components/Dice');
+const { createPlayer } = require('../testutils');
+const mockUIFactory = require('../mocks/UI');
+
+describe('Rules -> highestRollingPlayerGoesFirst', () => {
+  let userInterface;
+  let input;
+  let diceStub;
+
+  beforeEach(() => {
+    userInterface = mockUIFactory();
+    input = {
+      players: [
+        createPlayer({ name: 'Player1' }),
+        createPlayer({ name: 'Player2' }),
+      ],
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it(`should assign indices to each player`, () => {
+    highestRollingPlayerGoesFirst({ UI: userInterface }, input);
+    for (let index = 0; index < input.players.length; index++) {
+      expect(
+        input.players[index].id === index,
+        `Player index of ${index} does not match player position`
+      );
+    }
+  });
+
+  it('should make a call to the UI#prompt', () => {
+    const uiSpy = sinon.spy();
+    userInterface.prompt = uiSpy;
+    highestRollingPlayerGoesFirst({ UI: userInterface }, input);
+    expect(uiSpy.callCount).to.equal(
+      input.players.length,
+      `UI method for highestRollingPlayerGoesFirst was not called`
+    );
+  });
+  xit(`should reorder players based on random dice rolls if required`, () => {
+    diceStub = sinon.stub(Dice, 'roll');
+    input.players.push(createPlayer({ name: 'Player3' }));
+    input.players.push(createPlayer({ name: 'Player4' }));
+    input.players.push(createPlayer({ name: 'Player5' }));
+
+    diceStub.onCall(0).returns([1]);
+    diceStub.onCall(1).returns([2]);
+    diceStub.onCall(2).returns([3]);
+    diceStub.onCall(3).returns([4]);
+    diceStub.onCall(4).returns([6]);
+
+    highestRollingPlayerGoesFirst({ UI: userInterface }, input);
+    expect(input.players[4].name).to.equal(
+      'Player1',
+      'Unexpected player in order 4'
+    );
+    expect(input.players[3].name).to.equal(
+      'Player2',
+      'Unexpected player in order 3'
+    );
+    expect(input.players[2].name).to.equal(
+      'Player3',
+      'Unexpected player in order 2'
+    );
+    expect(input.players[1].name).to.equal(
+      'Player4',
+      'Unexpected player in order 1'
+    );
+    expect(input.players[0].name).to.equal(
+      'Player5',
+      'Unexpected player in order 0'
+    );
+  });
+  it(`should not reorder players based on random dice rolls if not required`, () => {
+    diceStub = sinon.stub(Dice, 'roll');
+    diceStub.onCall(0).returns([6]);
+    diceStub.onCall(1).returns([1]);
+
+    highestRollingPlayerGoesFirst({ UI: userInterface }, input);
+    expect(input.players[0].name).to.equal(
+      'Player1',
+      'Unexpected player in order 0'
+    );
+    expect(input.players[1].name).to.equal(
+      'Player2',
+      'Unexpected player in order 1'
+    );
+  });
+});

--- a/test/WealthService.test.js
+++ b/test/WealthService.test.js
@@ -98,4 +98,9 @@ describe('WealthService', () => {
       );
     });
   });
+  describe('calculateLiquidity', () => {
+    it('should calculate with mortgaged assets');
+    it('should calculate with constructed houses/hotels');
+    it('should calculate with no owned properties');
+  });
 });

--- a/test/WealthService.test.js
+++ b/test/WealthService.test.js
@@ -2,8 +2,6 @@ const expect = require('chai').expect;
 const WealthService = require('../entities/WealthService');
 const { GameState } = require('../entities/GameState');
 const { createPlayer } = require('./testutils');
-const config = require('../config/monopolyConfiguration');
-const { cloneDeep } = require('lodash');
 
 describe('WealthService', () => {
   let gameState;
@@ -16,7 +14,7 @@ describe('WealthService', () => {
     ];
     for (let id = 0; id < gameState.players.length; id++)
       gameState.players[id].id = id;
-    gameState.config = cloneDeep(config);
+    gameState.config = { propertyConfig: { properties: [] } };
   });
 
   describe('increment', () => {
@@ -103,10 +101,16 @@ describe('WealthService', () => {
   });
   describe('calculateLiquidity', () => {
     it('should calculate with mortgaged assets', () => {
-      let properties = gameState.config.propertyConfig.properties;
-      properties[0].ownedBy = 0; // price: 60
-      properties[1].ownedBy = 0; // price: 60
-      properties[1].mortgaged = true;
+      gameState.config.propertyConfig.properties = [
+        {
+          price: 60,
+          houseCost: 50,
+          buildings: 0,
+          mortgaged: false,
+          ownedBy: 0,
+        },
+        { price: 60, houseCost: 50, buildings: 0, mortgaged: true, ownedBy: 0 },
+      ];
 
       expect(WealthService.calculateLiquidity(gameState)).to.equal(
         1530,
@@ -114,10 +118,22 @@ describe('WealthService', () => {
       );
     });
     it('should calculate with constructed houses/hotels', () => {
-      let properties = gameState.config.propertyConfig.properties;
-      properties[0].ownedBy = 0; // price: 60
-      properties[1].ownedBy = 0; // price: 60
-      properties[1].buildings = 5; // houseCost: 50
+      gameState.config.propertyConfig.properties = [
+        {
+          price: 60,
+          houseCost: 50,
+          buildings: 0,
+          mortgaged: false,
+          ownedBy: 0,
+        },
+        {
+          price: 60,
+          houseCost: 50,
+          buildings: 5,
+          mortgaged: false,
+          ownedBy: 0,
+        },
+      ];
 
       expect(WealthService.calculateLiquidity(gameState)).to.equal(
         1685,
@@ -131,10 +147,17 @@ describe('WealthService', () => {
       );
     });
     it('should calculate with special properties', () => {
-      let properties = gameState.config.propertyConfig.properties;
-      properties[23].ownedBy = 0; // price: 150
-      properties[25].ownedBy = 0; // price: 200
-      properties[0].ownedBy = 0; // price: 60
+      gameState.config.propertyConfig.properties = [
+        {
+          price: 60,
+          houseCost: 50,
+          buildings: 0,
+          mortgaged: false,
+          ownedBy: 0,
+        },
+        { price: 150, mortgaged: false, ownedBy: 0 },
+        { price: 200, mortgaged: false, ownedBy: 0 },
+      ];
 
       expect(WealthService.calculateLiquidity(gameState)).to.equal(
         1705,
@@ -142,10 +165,17 @@ describe('WealthService', () => {
       );
     });
     it('should calculate specific player', () => {
-      let properties = gameState.config.propertyConfig.properties;
-      properties[23].ownedBy = 1; // price: 150
-      properties[25].ownedBy = 1; // price: 200
-      properties[0].ownedBy = 1; // price: 60
+      gameState.config.propertyConfig.properties = [
+        {
+          price: 60,
+          houseCost: 50,
+          buildings: 0,
+          mortgaged: false,
+          ownedBy: 1,
+        },
+        { price: 150, mortgaged: false, ownedBy: 1 },
+        { price: 200, mortgaged: false, ownedBy: 1 },
+      ];
 
       expect(
         WealthService.calculateLiquidity(gameState, gameState.players[1])

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -8,6 +8,7 @@ const mockUIFactory = require('./mocks/UI');
 const Dice = require('../entities/Components/Dice');
 const PlayerActions = require('../entities/PlayerActions');
 const config = require('../config/monopolyConfiguration');
+const { cloneDeep } = require('lodash');
 
 function gwt(strings) {
   const statements = strings.raw[0].split(' | ');
@@ -22,15 +23,14 @@ describe('main', () => {
     let gameState;
     let userInterface;
     let eventBus;
-    // mock?
-    // spy on functions?
+
     beforeEach(() => {
       gameState = new GameState();
       gameState.players = [
         createPlayer({ name: 'player1' }),
         createPlayer({ name: 'player2' }),
       ];
-      gameState.config = config;
+      gameState.config = cloneDeep(config);
       userInterface = mockUIFactory();
       eventBus = new EventEmitter();
     });
@@ -41,7 +41,7 @@ describe('main', () => {
     });
 
     it(
-      gwt`cold start | game is loaded | first player rolls dice and ends turn`,
+      gwt`cold start | game is loaded | first player rolls dice, buys properties, and ends turn`,
       () => {
         // arrange
         const promptStub = sinon.stub(PlayerActions, 'prompt');
@@ -50,9 +50,11 @@ describe('main', () => {
         promptStub.onCall(1).returns('');
         // player turn
         promptStub.onCall(2).returns('ROLL_DICE');
-        promptStub.onCall(3).returns('ROLL_DICE');
-        promptStub.onCall(4).returns('END_TURN');
-        promptStub.onCall(5).returns('END_GAME');
+        promptStub.onCall(3).returns('BUY_PROPERTY');
+        promptStub.onCall(4).returns('ROLL_DICE');
+        promptStub.onCall(5).returns('BUY_PROPERTY');
+        promptStub.onCall(6).returns('END_TURN');
+        promptStub.onCall(7).returns('END_GAME');
         const startGameSpy = sinon.spy();
         userInterface.startGame = startGameSpy;
         userInterface.prompt = promptStub;
@@ -63,7 +65,7 @@ describe('main', () => {
         diceStub.onCall(1).returns([1]);
 
         // player turn
-        diceStub.onCall(2).returns([1, 1]);
+        diceStub.onCall(2).returns([3, 3]);
         diceStub.onCall(3).returns([1, 2]);
 
         require('../entities/Game')({
@@ -75,15 +77,34 @@ describe('main', () => {
         expect(startGameSpy.callCount).to.equal(1, 'Game did not start');
         expect(gameState.turn).equal(1, 'Incorrect turn value');
         expect(gameState.players[0].position).to.equal(
-          5,
+          9,
           'Player #1 did not move'
+        );
+        expect(gameState.players[0].assets).to.equal(
+          220,
+          "Player #1's assets did not increase"
+        );
+        expect(gameState.players[0].cash).to.equal(
+          1280,
+          "Player #1's cash did not decrease"
         );
         expect(gameState.players[1].position).to.equal(0, 'Player #2 moved');
       }
     );
 
+    it(gwt`cold start | game is loaded | player caught speeding`, () => {
+      // continue or start
+    });
+
     it(
-      gwt`cold start | game is loaded | cannot end turn if first doubles has been rolled`,
+      gwt`cold start | game is loaded | player paying fine to get out of jail`,
+      () => {
+        // continue or start
+      }
+    );
+
+    it(
+      gwt`cold start | game is loaded | player paying fine to get out of jail after exhausting three turns`,
       () => {
         // continue or start
       }

--- a/test/mocks/UI.js
+++ b/test/mocks/UI.js
@@ -21,5 +21,7 @@ module.exports = function mockUIFactory() {
     jail: () => true,
     unknownAction: () => true,
     gameOver: () => true,
+    displayPropertyDetails: () => true,
+    propertyBought: () => true,
   };
 };

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -2,6 +2,7 @@ module.exports = {
   createPlayer: function ({ name }) {
     return {
       name,
+      id: 0,
       position: 0,
       jailed: -1,
       cash: 1500,

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -11,4 +11,11 @@ module.exports = {
       properties: [],
     };
   },
+
+  fillStub: function (stub, stubValues) {
+    for (let [index, value] of stubValues.entries()) {
+      stub.onCall(index).returns(value);
+    }
+    return stub;
+  },
 };


### PR DESCRIPTION
- Adds resolution of new property, including purchasing it.
- Adds id to player to avoid doing calculation every time for a player
- Removes unnecessary README docs that have been migrated to GitHub
- Adds more integration tests
- CalculateLiquidity now takes into consideration special properties and mortgaged props
