### PR TITLE
feat/liquidation

### DIFF
--- a/ConsoleUI.js
+++ b/ConsoleUI.js
@@ -70,6 +70,11 @@ const consoleUI = (function (readline) {
     luxuryTaxPaid: (cost) => {
       console.log(`LUXURY TAX: Paid a total of $${cost}`);
     },
+    playerShortOnFunds: (cashOnHand, price) => {
+      console.log(
+        `💰💰💰: Insufficient funds ($${cashOnHand}) to afford payment ($${price})`
+      );
+    },
   };
 })(require('readline-sync'));
 

--- a/test/Rules/BUY_PROPERTY.test.js
+++ b/test/Rules/BUY_PROPERTY.test.js
@@ -93,10 +93,10 @@ describe('Rules -> BUY_PROPERTY', () => {
       userInterface.playerShortOnFunds = uiSpy;
       const property =
         gameState.config.propertyConfig.properties[TEST_PROPERTY];
-      gameState.currentBoardProperty = property; // price: 60
-      gameState.currentPlayer.cash = 50;
+      gameState.currentBoardProperty = property;
+      gameState.currentPlayer.cash = property.price - 1;
       liquidationStub.callsFake(() => {
-        gameState.currentPlayer.cash += 50;
+        gameState.currentPlayer.cash += property.price - 1;
       });
 
       eventBus.emit(inputEvent);
@@ -109,10 +109,10 @@ describe('Rules -> BUY_PROPERTY', () => {
     it(`should make a call to the ${liquidationStub} when funds are insufficient`, () => {
       const property =
         gameState.config.propertyConfig.properties[TEST_PROPERTY];
-      gameState.currentBoardProperty = property; // price: 60
-      gameState.currentPlayer.cash = 50;
+      gameState.currentBoardProperty = property;
+      gameState.currentPlayer.cash = property.price - 1;
       liquidationStub.callsFake(() => {
-        gameState.currentPlayer.cash += 50;
+        gameState.currentPlayer.cash += property.price - 1;
       });
 
       eventBus.emit(inputEvent);

--- a/test/Rules/INCOME_TAX.test.js
+++ b/test/Rules/INCOME_TAX.test.js
@@ -118,13 +118,30 @@ describe('Rules -> INCOME_TAX', () => {
         }% of networth when VARIABLE was chosen for payment `
       );
     });
+    it('should decrease player cash by config incomeTaxRate if player chooses VARIABLE, rounded to 2 decimal places', () => {
+      const startingCash = gameState.currentPlayer.cash;
+      const assets = 11;
+      gameState.currentPlayer.assets = assets;
+      const promptStub = sinon.stub(PlayerActions, 'prompt');
+      promptStub.onCall(0).returns('VARIABLE');
+
+      eventBus.emit(inputEvent);
+      expect(gameState.currentPlayer.cash).to.equal(
+        startingCash -
+          ((startingCash + assets) * config.incomeTaxRate).toFixed(2),
+        `Player did not pay ${
+          100 * config.incomeTaxRate
+        }% of networth when VARIABLE was chosen for payment `
+      );
+    });
     it('should make a call to the UI#incomeTaxPaid for VARIABLE', () => {
       const uiSpy = sinon.spy();
       userInterface.incomeTaxPaid = uiSpy;
       const promptStub = sinon.stub(PlayerActions, 'prompt');
       promptStub.onCall(0).returns('VARIABLE');
-      const expectedFee =
-        gameState.config.incomeTaxRate * gameState.currentPlayer.cash;
+      const expectedFee = (
+        gameState.config.incomeTaxRate * gameState.currentPlayer.cash
+      ).toFixed(2);
 
       eventBus.emit(inputEvent);
       expect(uiSpy.calledOnceWithExactly(expectedFee)).to.equal(

--- a/test/Rules/INCOME_TAX.test.js
+++ b/test/Rules/INCOME_TAX.test.js
@@ -113,14 +113,14 @@ describe('Rules -> INCOME_TAX', () => {
       eventBus.emit(inputEvent);
       expect(gameState.currentPlayer.cash).to.equal(
         startingCash - startingCash * config.incomeTaxRate,
-        `Player did not pay ${
+        `Player did not pay $${
           100 * config.incomeTaxRate
         }% of networth when VARIABLE was chosen for payment `
       );
     });
     it('should decrease player cash by config incomeTaxRate if player chooses VARIABLE, rounded to 2 decimal places', () => {
       const startingCash = gameState.currentPlayer.cash;
-      const assets = 11;
+      const assets = 11; // arbitrary value
       gameState.currentPlayer.assets = assets;
       const promptStub = sinon.stub(PlayerActions, 'prompt');
       promptStub.onCall(0).returns('VARIABLE');
@@ -129,7 +129,7 @@ describe('Rules -> INCOME_TAX', () => {
       expect(gameState.currentPlayer.cash).to.equal(
         startingCash -
           ((startingCash + assets) * config.incomeTaxRate).toFixed(2),
-        `Player did not pay ${
+        `Player did not pay $${
           100 * config.incomeTaxRate
         }% of networth when VARIABLE was chosen for payment `
       );

--- a/test/Rules/LIQUIDATION.test.js
+++ b/test/Rules/LIQUIDATION.test.js
@@ -1,0 +1,114 @@
+const expect = require('chai').expect;
+const EventEmitter = require('events');
+const sinon = require('sinon');
+const mockUIFactory = require('../mocks/UI');
+
+const { GameState } = require('../../entities/GameState');
+const PlayerActions = require('../../entities/PlayerActions');
+const { createPlayerFactory } = require('../testutils');
+const config = require('../../config/monopolyConfiguration');
+const { cloneDeep } = require('lodash');
+
+describe('Rules -> LIQUIDATION', () => {
+  let gameState;
+  let userInterface;
+  let eventBus;
+  const RULES = require('../../entities/Rules');
+
+  beforeEach(() => {
+    gameState = new GameState();
+    eventBus = new EventEmitter();
+    userInterface = mockUIFactory();
+    let createPlayer = createPlayerFactory();
+    gameState.players = [createPlayer({ name: 'player1' })];
+    gameState.config = cloneDeep(config);
+  });
+
+  afterEach(() => {
+    // Restore the default sandbox here
+    sinon.restore();
+  });
+
+  describe('liquidation', () => {
+    const inputEvent = 'LIQUIDATION';
+    const managePropertiesEvent = 'MANAGE_PROPERTIES';
+    const tradeEvent = 'TRADE';
+    const bankruptcyEvent = 'BANKRUPTCY';
+    const cancelEvent = 'CANCEL';
+
+    let liquidationSpy;
+    let managePropertiesSpy;
+    let tradeSpy;
+    let bankruptcySpy;
+
+    beforeEach(() => {
+      let { emit: notify } = eventBus;
+      notify = notify.bind(eventBus);
+
+      RULES[inputEvent].forEach((handler) =>
+        eventBus.on(
+          inputEvent,
+          handler.bind(null, { notify, UI: userInterface }, gameState)
+        )
+      );
+      liquidationSpy = sinon.spy();
+      managePropertiesSpy = sinon.spy();
+      tradeSpy = sinon.spy();
+      bankruptcySpy = sinon.spy();
+
+      eventBus.on(inputEvent, liquidationSpy);
+      eventBus.on(managePropertiesEvent, managePropertiesSpy);
+      eventBus.on(tradeEvent, tradeSpy);
+      eventBus.on(bankruptcyEvent, bankruptcySpy);
+    });
+
+    it(`should emit desired ${managePropertiesEvent} event`, () => {
+      const promptStub = sinon.stub(PlayerActions, 'prompt');
+      promptStub.onCall(0).returns(managePropertiesEvent);
+      promptStub.onCall(1).returns(cancelEvent);
+      eventBus.emit(inputEvent);
+      expect(managePropertiesSpy.callCount).to.equal(
+        1,
+        `${managePropertiesEvent} was called ${managePropertiesSpy.callCount} times but expected to be 1 times`
+      );
+    });
+    it(`should emit desired ${tradeEvent} event`, () => {
+      const promptStub = sinon.stub(PlayerActions, 'prompt');
+      promptStub.onCall(0).returns(tradeEvent);
+      promptStub.onCall(1).returns(cancelEvent);
+      eventBus.emit(inputEvent);
+      expect(tradeSpy.callCount).to.equal(
+        1,
+        `${tradeEvent} was called ${tradeSpy.callCount} times but expected to be 1 times`
+      );
+    });
+    it(`should emit desired ${bankruptcyEvent} event`, () => {
+      const promptStub = sinon.stub(PlayerActions, 'prompt');
+      promptStub.onCall(0).returns(bankruptcyEvent);
+
+      eventBus.emit(inputEvent);
+
+      expect(bankruptcySpy.callCount).to.equal(
+        1,
+        `${bankruptcyEvent} was called ${bankruptcySpy.callCount} times but expected to be 1 times`
+      );
+    });
+    it('should make a call to the UI#unknownAction if action input is not recognized', () => {
+      const uiSpy = sinon.spy();
+      userInterface.unknownAction = uiSpy;
+
+      const promptStub = sinon.stub(PlayerActions, 'prompt');
+      promptStub.onCall(0).returns(undefined);
+      promptStub.onCall(1).returns(cancelEvent);
+      eventBus.emit(inputEvent);
+      expect(uiSpy.calledOnce).to.equal(
+        true,
+        `UI method for ${inputEvent} was not called`
+      );
+      expect(liquidationSpy.callCount).to.equal(
+        2,
+        `Unknown action did not trigger ${inputEvent} event again`
+      );
+    });
+  });
+});

--- a/test/Rules/MORTGAGE.test.js
+++ b/test/Rules/MORTGAGE.test.js
@@ -71,7 +71,7 @@ describe('Rules -> MORTGAGE', () => {
       promptStub.onCall(0).returns(cancelEvent);
       eventBus.emit(inputEvent);
       expect(promptStub.getCall(0).args[2]).to.deep.equal(
-        [...expectedProperties.map((p) => p.name), 'CANCEL'],
+        [...expectedProperties.map((p) => p.name.toUpperCase()), 'CANCEL'],
         `Unexpected prompt input for mortgage properties list: ${
           promptStub.getCall(0).args[2]
         }`
@@ -121,7 +121,7 @@ describe('Rules -> MORTGAGE', () => {
       const originalMortgageState = expectedProperty.mortgaged;
 
       const promptStub = sinon.stub(PlayerActions, 'prompt');
-      promptStub.onCall(0).returns(expectedProperty.name);
+      promptStub.onCall(0).returns(expectedProperty.name.toUpperCase());
       promptStub.onCall(1).returns(cancelEvent);
       eventBus.emit(inputEvent);
       expect(expectedProperty.mortgaged).to.equal(
@@ -143,14 +143,14 @@ describe('Rules -> MORTGAGE', () => {
       const originalMortgageState = expectedProperty.mortgaged;
 
       const promptStub = sinon.stub(PlayerActions, 'prompt');
-      promptStub.onCall(0).returns(expectedProperty.name);
+      promptStub.onCall(0).returns(expectedProperty.name.toUpperCase());
       promptStub.onCall(1).returns(cancelEvent);
       eventBus.emit(inputEvent);
       expect(expectedProperty.mortgaged).to.equal(
         originalMortgageState,
         `${inputEvent} was called with valid property without sufficient funds and mortgage was toggled`
       );
-      expect(uiSpy.calledOnce).to.equal(
+      expect(uiSpy.calledOnceWithExactly(gameState.currentPlayer)).to.equal(
         true,
         `UI method for ${inputEvent} was not called although player has insufficient funds`
       );

--- a/test/mocks/UI.js
+++ b/test/mocks/UI.js
@@ -28,5 +28,6 @@ module.exports = function mockUIFactory() {
     incomeTaxPayment: () => true,
     incomeTaxPaid: () => true,
     luxuryTaxPaid: () => true,
+    playerShortOnFunds: () => true,
   };
 };


### PR DESCRIPTION
Depends on the previous two PRs.

Depends on Trade functionality to be written later once cards are in the game.

Design Decision: we need to design how bankruptcy will work. 
1. Maybe a flag on the player so that all future rules will know to either skip the player or end the previous action (paying rent, paying fine, mortgaging, paying tax). 
2. Do we need to revisit turn logic because that is tied to our # of players to work?

#21 